### PR TITLE
Make shebang more general for python3

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import urllib.request
 import json


### PR DESCRIPTION
Shebang should be independet of $PATH and this script currently requires python3 AFAIK